### PR TITLE
Align v0.1.2 release notes across docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [0.1.2] - 2025-10-01
 ### Fixed
-- Improved error handling for `--input-json` snapshots to gracefully report malformed data instead of crashing.
+- Hardened `--input-json` parsing so malformed snapshots trigger a clear error instead of a crash.
 
 ### Documentation
-- Added a complete CLI usage guide (including bare `python` invocation) in the README and the new `USAGE.md` reference.
+- Expanded end-to-end CLI guidance: refreshed the README quickstart and added the dedicated `USAGE.md` reference guide.
 
 ## [0.1.1] - 2025-09-30
 ### Added

--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ See [USAGE.md](USAGE.md) for a full rundown of every CLI option, defaults, and e
 ## Changelog
 
 ### 0.1.2 — 2025-10-01
-- Fixed error handling when parsing input JSON snapshots to avoid crashes on malformed data.
-- Documented end-to-end CLI usage, including a full example bare `python` invocation and reference guide.
+- Hardened `--input-json` parsing so malformed snapshots are reported cleanly instead of crashing the run.
+- Expanded docs: refreshed the README quickstart and added a dedicated `USAGE.md` reference guide.
 
 ### 0.1.1 — 2025-09-30
 - Logger uses bounded buffer (deque) + line-buffered file writes to avoid unbounded memory growth.

--- a/USAGE.md
+++ b/USAGE.md
@@ -44,7 +44,7 @@ homedoc-tailscale-status \
 | `--debug` | Emit verbose logging to stdout and log file. | Disabled |
 | `--log-file PATH` | Write logs to an explicit path instead of `OUT/<run>/homedoc.log`. | `None` (auto) |
 | `--timeout SECONDS` | Timeout for `tailscale` subprocess and LLM HTTP calls. | `60` (via `HOMEDOC_HTTP_TIMEOUT`) |
-| `--input-json FILE` | Use a saved `tailscale status --json` output instead of calling `tailscale`. | Requires readable file |
+| `--input-json FILE` | Use a saved `tailscale status --json` output instead of calling `tailscale`; malformed files now produce a clear error instead of a crash. | Requires readable file |
 | `--no-llm` | Skip LLM call; still writes snapshot and Markdown table/findings. | Disabled |
 | `--json-only` | Only emit JSON artifacts (`status.json`, `snapshot.json`, `insights.json`). | Disabled |
 | `--llm-mode {auto,generate,chat}` | Select Ollama HTTP path preference. | `auto` (via `HOMEDOC_LLM_MODE`) |

--- a/homedoc_tailscale_status.py
+++ b/homedoc_tailscale_status.py
@@ -9,13 +9,8 @@ Single-file, stdlib-only utility that:
   4) writes artifacts into a per-run folder with a local-time timestamp (unless --flat).
 
 v0.1.2 (2025-10-01)
-- Logger uses bounded buffer (deque) to avoid unbounded memory growth; optional live file streaming
-- Consolidated error handling: helpers raise; main() maps to consistent exit codes
-- Safer JSON extraction using json.JSONDecoder.raw_decode (replacing manual brace walker)
-- Streaming hardened: clearer timeouts, minimal-progress watchdog, graceful fallback
-- Markdown table escapes pipe characters; short findings section even without LLM
-- CLI: new --json-only flag; clarified --flat semantics; early logging of resolved model tag
-- Minor FS improvements: create output dir & open log early; line-buffered writes
+- Hardened `--input-json` parsing so malformed snapshots are reported cleanly instead of crashing the run.
+- Expanded docs: refreshed the README quickstart and added a dedicated `USAGE.md` reference guide.
 
 License: GPLv3
 """


### PR DESCRIPTION
## Summary
- sync the v0.1.2 release notes in the script banner, README, and CHANGELOG
- clarify the `--input-json` option in USAGE.md to note the hardened malformed JSON handling
- create the v0.1.2 git tag to finish the release bookkeeping

## Testing
- python -m compileall homedoc_tailscale_status.py

------
https://chatgpt.com/codex/tasks/task_b_68dd44167e60832c8a34bf1a2c723f7f